### PR TITLE
EN - Fixed hyperlink in Getting Started project

### DIFF
--- a/en-GB/getting-started/index.md
+++ b/en-GB/getting-started/index.md
@@ -197,4 +197,4 @@ If you are connected to the internet then you can also try browsing the web.
 
 + Can you find out how the Raspberry Pi got its name?
 
-Note: You can also try any of the regular [Code Club projects](codeclubprojects.org) on the Raspberry Pi.
+Note: You can also try any of the regular [Code Club projects](https://codeclubprojects.org/) on the Raspberry Pi.


### PR DESCRIPTION
While working on the French translation, I noticed that the hyperlink to codeclubprojects.org was not working. I fixed it by using absolute link instead of relative link.